### PR TITLE
Broaden the number of csv timestamp format hbGPS can handle

### DIFF
--- a/R/load_and_tidy_up_GPS.R
+++ b/R/load_and_tidy_up_GPS.R
@@ -1,5 +1,8 @@
 load_and_tidy_up_GPS = function(gps_file, idloc = NULL, tz = "", time_format = "%d/%m/%Y %H:%M:%SO") {
   df = data.table::fread(file = gps_file, data.table = FALSE)
+  if (all(c("V1", "V2", "V3", "V4") %in% colnames(df)[1:4])) {
+    df = data.table::fread(file = gps_file, data.table = FALSE, header = TRUE)
+  }
   if ("ptid" %in% colnames(df)) { # Specific for MSSE dataset
     UID = unique(df$ptid)
     ID = UID[7]
@@ -13,29 +16,55 @@ load_and_tidy_up_GPS = function(gps_file, idloc = NULL, tz = "", time_format = "
     ID = unlist(strsplit(basename(gps_file), "[.]"))[1]
   }
   
-  #===========================================
+  #==================================0=========
   # Standardise format
   colnames(df) = tolower(colnames(df))
-  colnames(df) = gsub(pattern = "local date", replacement = "date", x = colnames(df))
-  colnames(df) = gsub(pattern = "local time", replacement = "time", x = colnames(df))
-  colnames(df) = gsub(pattern = "speed[(]km/h[)]", replacement = "speed_kmh", x = colnames(df))
-  colnames(df) = gsub(pattern = "height[(]m[)]", replacement = "height_m", x = colnames(df))
-  colnames(df) = gsub(pattern = "latitude", replacement = "lat", x = colnames(df))
-  colnames(df) = gsub(pattern = "longitude", replacement = "lon", x = colnames(df))
-  colnames(df) = gsub(pattern = "nsat[(]used/view[)]", replacement = "nsat_uv", x = colnames(df))
-  colnames(df) = gsub(pattern = "nsat [(]used/view[)]", replacement = "nsat_uv", x = colnames(df))
-  colnames(df)[grep(pattern = "sat info ", x = colnames(df))] = "satinfo"
-  # cat(paste0("\nLATITUDE ", mean(df$lat), " longitude ", mean(df$lon), "\n"))
+  
   # Time
-  if (length(grep(pattern = "sensecam", x = colnames(df))) > 0) {
+  if (any(c("time", "date") %in% colnames(df))) {
+    stop(paste0("GPS data is expected to not have a column named \"time\" ",
+                "or \"date\". Please replace by \"local time\" and \"local date\" ",
+                " \"utc time\" and \"utc date\" ,or \"datetime\"."))
+  }
+  # Identify whether UTC time needs to be converted to local time
+  convert_UTC2local = FALSE
+  if ("local time" %in% colnames(df) &&
+      length(grep(pattern = "T| ", x = format(df$`local time`[1]))) > 0) {
+    # local time is the full date time
+    colnames(df) = gsub(pattern = "local time", replacement = "datetime", x = colnames(df))
+  } else if (all(c("local time", "local date") %in% colnames(df))) {
+    # local time and local date are stored separately
+    colnames(df) = gsub(pattern = "local time", replacement = "time", x = colnames(df))
+    colnames(df) = gsub(pattern = "local date", replacement = "date", x = colnames(df))
+    df = df[, which(colnames(df) %in% c("utc time", "utc date") == FALSE)]
+  } else if (all(c("utc time", "utc date") %in% colnames(df))) {
+    # local time and ate are missing, but utc time and date are present
+    convert_UTC2local = TRUE
+    colnames(df) = gsub(pattern = "utc time", replacement = "time", x = colnames(df))
+    colnames(df) = gsub(pattern = "utc date", replacement = "date", x = colnames(df))
+  } else {
+    # none of the above worked, give warning
+    stop(paste0("GPS data is expected to either have column \"datetime\" (expressed in local timezone)",
+                " or columns \"utc time\" and \"utc date\" ",
+                "or columns \"local time\" and \"local date\""))
+  }
+  if ("datetime" %in% colnames(df)) {
     oldtime = df$datetime[pmin(10, nrow(df))]
-    newTime = as.POSIXct(df$datetime,
-                         tz = tz, format = time_format, origin = "1970-01-01")
+    newTime = as.POSIXct(df$datetime, tz = tz, format = time_format,
+                         origin = "1970-01-01")
   } else {
     oldtime = paste0(df$date[pmin(10, nrow(df))], " ", df$time[pmin(10, nrow(df))])
-    newTime = as.POSIXct(paste(df$date, df$time, sep = " "),
-                         tz = tz, format = time_format, origin = "1970-01-01")
+    if (convert_UTC2local == TRUE) {
+      newTime = as.POSIXct(as.POSIXct(paste(df$date, df$time, sep = " "),
+                                      tz = "UTC", format = time_format,
+                                      origin = "1970-01-01"), tz = tz)
+    } else {
+      newTime = as.POSIXct(paste(df$date, df$time, sep = " "),
+                           tz = tz, format = time_format,
+                           origin = "1970-01-01")
+    }
   }
+  # Check that timestamp conversion worked
   if (any(is.na(newTime[1:pmin(100, length(newTime))])) == TRUE) {
     stop(paste0("Specified time_format is ", time_format, " we see ", oldtime))
   } else {
@@ -43,18 +72,51 @@ load_and_tidy_up_GPS = function(gps_file, idloc = NULL, tz = "", time_format = "
   }
   # Order by timestamp
   df = df[order(df$time), ]
+  colnames(df) = gsub(pattern = "height[(]m[)]", replacement = "height_m", x = colnames(df))
+  colnames(df) = gsub(pattern = "latitude", replacement = "lat", x = colnames(df))
+  colnames(df) = gsub(pattern = "longitude", replacement = "lon", x = colnames(df))
+  colnames(df) = gsub(pattern = "nsat[(]used/view[)]", replacement = "nsat_uv", x = colnames(df))
+  colnames(df) = gsub(pattern = "nsat [(]used/view[)]", replacement = "nsat_uv", x = colnames(df))
+  colnames(df)[grep(pattern = "sat info ", x = colnames(df))] = "satinfo"
+  # cat(paste0("\nLATITUDE ", mean(df$lat), " longitude ", mean(df$lon), "\n"))
   
+  if ("satinfo" %in% colnames(df) == FALSE && all(c("sid", "snr") %in% colnames(df))) {
+    # merge sid and snr to keep it consistent with expected satinfo column
+    fuse_sid_snr = function(x) {
+      sid  = unlist(strsplit(x[1], ";"))
+      snr = unlist(strsplit(x[2], ";"))
+      satinfo = paste0(paste0(sid, snr), collapse = ";")
+      return(satinfo)
+    }
+    df$satinfo = apply(X = df[, c("sid", "snr")], MARGIN = 1, FUN = fuse_sid_snr)
+  }
+  if ("nsat_uv" %in% colnames(df) == FALSE && all(c("sid", "nsat") %in% colnames(df))) {
+    df$nsat = suppressWarnings(as.numeric(df$nsat)) # force to number and set character values to missing
+    create_nsatview = function(x) {
+      nview  = length(unlist(strsplit(x[1], ";")))
+      nsat = x[2]
+      nsatview = paste0(paste0(nsat, "(", nview, ")"), collapse = ";")
+      return(nsatview)
+    }
+    df$nsat_uv = apply(X = df[, c("sid", "nsat")], MARGIN = 1, FUN = create_nsatview)
+  }
+
   # Remove duplicates
   Nduplicated = length(which(duplicated(df[, c("time", "lon", "lat")]) == TRUE))
   if (Nduplicated > 0) {
-    warning(paste0(Nduplicated, " duplicated data points found, check whether timestamps have seconds"))
+    if (Nduplicated > 10) {
+      warning(paste0(Nduplicated, " duplicated data points found, check whether timestamps have seconds"))
+    }
     df = df[!duplicated(df[, c("time", "lon", "lat")]),]
   }
   
   # Remove some columns that will not be used
-  df = df[, which(colnames(df) %in% c("distance", "speed_kmh",
+  df = df[, which(colnames(df) %in% c("distance", "speed[(]km/h[)]",
                                    "dsta", "dage", "pdop", "vdop", "nsat", "sid", "valid",
                                    "hdop", "azimuth", "snr", "rcr", "ms") == FALSE)]
+  df$lon = suppressWarnings(as.numeric(df$lon)) # force to number and set character values to missing
+  df$lat = suppressWarnings(as.numeric(df$lat)) # force to number and set character values to missing
+  df = df[which(is.na(df$lon) == FALSE & is.na(df$lat) == FALSE),]
   
   # Flip lon if coordinates are in the west
   if ("e/w" %in% colnames(df) & all(df$lon > 0)) {
@@ -64,6 +126,5 @@ load_and_tidy_up_GPS = function(gps_file, idloc = NULL, tz = "", time_format = "
   if ("n/s" %in% colnames(df) & all(df$lat > 0)) {
     df$lat = df$lat * ifelse(df$`n/s` == "S", yes = -1, no = 1)
   }
-  
   invisible(list(df = df, ID = ID))
 }

--- a/R/mergeGGIR.R
+++ b/R/mergeGGIR.R
@@ -17,7 +17,7 @@ mergeGGIR = function(GGIRpath, GPSdf, ID, verbose) {
   
   # select first time series in the folder, maybe later make this flexible to select specific time series
   GGIR_ts_paths = dir(items[grep(pattern = "behavioralcodes", x = basename(items), invert = TRUE)][1], full.names = TRUE)
-  GGIR_ts_path = GGIR_ts_paths[grep(pattern = ID, x = GGIR_ts_paths, value = FALSE)]
+  GGIR_ts_path = GGIR_ts_paths[grep(pattern = ID, x = basename(GGIR_ts_paths), value = FALSE)]
   log_acc = 1
   if (length(GGIR_ts_path) != 0) {
     log_acc = 2  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/man/load_and_tidy_up_GPS.Rd
+++ b/man/load_and_tidy_up_GPS.Rd
@@ -26,13 +26,24 @@
 }
 \details{
   The code ignores letter case when reading column names. The GPS csv file is 
-  expected to have the following column names: latitude or lat; longitude or lon;
-  nat(used/view) or nat (used/view) where the value format can be
-  3 (2), 3(2), 3/2, 3 / 2; a column with at least the character string "sat info " 
+  expected to have the following column names: latitude; longitude;
+  a column name height(m); a column named speed(km/h); 
+  a column local data or just date, and; a column local time or just time.
+  
+  A column with at least the character string "sat info " 
   where the valueformat can be "(1-1-1-10);(1-1-1-10)" or "#1-1-1-10;#1-1-1-10" where
   the number values per substring does not have to be 4 but the last value is always assumed
-  to reflect SNR; a column name height(m); a column named speed(km/h); 
-  a column local data or just date, and; a column local time or just time.
+  to reflect SNR. If sat info is not available then the code assumes that there is a sid and snr,
+  which when values are fused pairwise reflect the sat info value.
+  
+  Satiliate information is either provided with column nsat(used/view) or 
+  nsat (used/view) where the value format can be
+  3 (2), 3(2), 3/2, 3 / 2. If nsat(used/view) column is not available the code will
+  look for column nsat and extracts from the sid column the number of satilites in view.
+  
+  Timestamps are expected to be available as either: "datetime" column in local timezone,
+  "time" and "date" columns in local timezone, "local time" and "local date"
+  column, or "utc time" and "utc date" column.
 }
 \value{
   List with a data.frame df that holds the GPS time series


### PR DESCRIPTION
This PR fixes #17 
- broadens the number of accepted ways to provide time and date.
- updates documentation of the expected GPS csv file format
- better handles irregularities in csv file
